### PR TITLE
Removed anonymous lifetimes

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -32,7 +32,7 @@ enum CtxError {
 }
 
 impl fmt::Display for CtxError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use CtxError::*;
         match self {
             MissingBinding(name) => write!(

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -13,7 +13,7 @@ pub enum Term {
 }
 
 impl fmt::Display for Term {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Term::Unit => write!(f, "unit"),
             Term::Var(index) => write!(f, "{}", *index),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,7 +20,7 @@ pub enum NamedTerm {
 }
 
 impl fmt::Display for NamedTerm {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             NamedTerm::Unit => write!(f, "unit"),
             NamedTerm::Var(var) => write!(f, "{}", *var as char),

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -9,7 +9,7 @@ pub enum Ty {
 }
 
 impl fmt::Display for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Ty::Unit => write!(f, "Unit"),
             Ty::Arrow(t1, t2) => write!(f, "({} -> {})", t1, t2),


### PR DESCRIPTION
The lifetimes on `Formatter` (like `Formatter<'_>`) aren't actually need,
despite a lot of Rust sources including them, as Rust is smart enough to
figure them out, so they only serve to add noise.


(This is obviously just a stylistic issue, but I think it's valuable to reduce the amount of unnecessary lifetime information. It's one of the things newcomers dislike most about Rust, so minimizing it to where it's needed is preferable in my humble opinion.)