### PR TITLE
Use `char`s instead of `u8`.

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -32,7 +32,7 @@ enum CtxError {
 }
 
 impl fmt::Display for CtxError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use CtxError::*;
         match self {
             MissingBinding(name) => write!(

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -13,7 +13,7 @@ pub enum Term {
 }
 
 impl fmt::Display for Term {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Term::Unit => write!(f, "unit"),
             Term::Var(index) => write!(f, "{}", *index),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,14 +8,14 @@ use parser::parse;
 
 fn main() {
     let inputs =
-        [r"(let i = (\z:(Unit -> Unit). z) in ((\x:((Unit -> Unit) -> (Unit -> Unit)). (x (\y:Unit. y))) i))"];
+        [r"(let i = (\z:(Unit -> Unit). z) in ((λx:((Unit -> Unit) -> (Unit -> Unit)). (x (\y:Unit. y))) i))"];
 
     for input in &inputs {
-        run(input).unwrap();
+        run(input.to_string()).unwrap();
     }
 }
 
-fn run(input: &str) -> Option<()> {
+fn run(input: String) -> Option<()> {
     println!("\nInput: {}", input);
     let named_term = parse(input)?;
     println!("Parsed term: {}", named_term);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
         [r"(let i = (\z:(Unit -> Unit). z) in ((\x:((Unit -> Unit) -> (Unit -> Unit)). (x (\y:Unit. y))) i))"];
 
     for input in &inputs {
-        run(input);
+        run(input).unwrap();
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,7 +20,7 @@ pub enum NamedTerm {
 }
 
 impl fmt::Display for NamedTerm {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             NamedTerm::Unit => write!(f, "unit"),
             NamedTerm::Var(var) => write!(f, "{}", *var as char),

--- a/src/parser/result.rs
+++ b/src/parser/result.rs
@@ -15,21 +15,21 @@ impl ParseError {
 }
 
 impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Parsing error at location {}", self.loc)
     }
 }
 
 pub enum ParseErrorKind {
-    InvalidByte(u8),
+    InvalidChar(char),
     UnexpectedToken(TokenKind),
 }
 
 impl fmt::Display for ParseErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ParseErrorKind::*;
         match self {
-            &InvalidByte(byte) => write!(f, "Invalid byte {:?}", byte as char),
+            &InvalidChar(c) => write!(f, "Invalid byte {}", c),
             UnexpectedToken(token) => write!(f, "Unexpected token '{:?}'", token),
         }
     }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -9,7 +9,7 @@ pub enum Ty {
 }
 
 impl fmt::Display for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Ty::Unit => write!(f, "Unit"),
             Ty::Arrow(t1, t2) => write!(f, "({} -> {})", t1, t2),


### PR DESCRIPTION
Closes #3 

This changes the `u8`s and usage of bytes into `char`s. It's a bit ugly, but it does the job, and does in fact work (as demonstrated in the updated test case).

Also, I renamed `ParseErrorKind::InvalidByte` into `ParseErrorKind::InvalidChar` to reflect the new changes.